### PR TITLE
Add the MinTree data structure that is based on the mafsa package

### DIFF
--- a/levenshtein.go
+++ b/levenshtein.go
@@ -5,7 +5,6 @@ package levenshtein
 type SparseAutomaton struct {
 	str string
 	max int
-	sl  int
 }
 
 // NewSparseAutomaton creates a new automaton for the string s, with a given max edit distance check

--- a/levenshtein_rune.go
+++ b/levenshtein_rune.go
@@ -1,0 +1,77 @@
+package levenshtein
+
+// SparseAutomatonRune is almost identical to SparseAutomaton except
+// that it operates on runes instead of bytes
+type SparseAutomatonRune struct {
+	SparseAutomaton
+	runes []rune
+}
+
+// NewSparseAutomatonRune creates a new automaton for the string s,
+// with a given max edit distance check
+func NewSparseAutomatonRune(s string, maxEdits int) *SparseAutomatonRune {
+	return &SparseAutomatonRune{
+		SparseAutomaton{max: maxEdits},
+		[]rune(s),
+	}
+}
+
+func (a *SparseAutomatonRune) Transitions(v sparseVector) []rune {
+	set := map[rune]struct{}{}
+
+	for _, entry := range v {
+		if entry.idx < len(a.runes) {
+			set[a.runes[entry.idx]] = struct{}{}
+		}
+	}
+
+	ret := make([]rune, 0, len(set))
+	for r, _ := range set {
+		ret = append(ret, r)
+	}
+
+	return ret
+}
+
+// StepRune returns the next state of the automaton given a pervios
+// state and a rune to check
+func (a *SparseAutomatonRune) Step(state sparseVector, r rune) sparseVector {
+	newVec := make(sparseVector, 0)
+
+	if len(state) > 0 && state[0].idx == 0 && state[0].val < a.max {
+		newVec = newVec.append(0, state[0].val+1)
+	}
+
+	for j, entry := range state {
+		if entry.idx == len(a.runes) {
+			break
+		}
+
+		cost := 0
+		if a.runes[entry.idx] != r {
+			cost = 1
+		}
+
+		val := state[j].val + cost
+		if len(newVec) != 0 && newVec[len(newVec)-1].idx == entry.idx {
+			val = min(val, newVec[len(newVec)-1].val+1)
+		}
+
+		if len(state) > j+1 && state[j+1].idx == entry.idx+1 {
+			val = min(val, state[j+1].val+1)
+		}
+
+		if val <= a.max {
+			newVec = newVec.append(entry.idx+1, val)
+		}
+	}
+
+	return newVec
+}
+
+// IsMatch returns true if the current state vector represents a string
+// of runes that is within the max edit distance from the initial
+// automaton string
+func (a *SparseAutomatonRune) IsMatch(v sparseVector) bool {
+	return len(v) != 0 && v[len(v)-1].idx == len(a.runes)
+}

--- a/levenshtein_test.go
+++ b/levenshtein_test.go
@@ -95,7 +95,10 @@ func TestTrie(t *testing.T) {
 
 }
 
-var trie *Trie
+var (
+	trie      *Trie
+	testwords []string
+)
 
 func BenchmarkTrie(b *testing.B) {
 
@@ -112,7 +115,8 @@ func BenchmarkTrie(b *testing.B) {
 func TestMain(m *testing.M) {
 
 	trie = NewTrie()
-	for _, word := range SampleEnglish() {
+	testwords = SampleEnglish()
+	for _, word := range testwords {
 		trie.Insert(word)
 	}
 
@@ -123,11 +127,10 @@ func TestMain(m *testing.M) {
 }
 
 func SampleEnglish() []string {
-	var out []string
 	file, err := os.Open("./big.txt")
 	if err != nil {
 		fmt.Println(err)
-		return out
+		return testwords
 	}
 	defer file.Close()
 	reader := bufio.NewReader(file)
@@ -141,7 +144,7 @@ func SampleEnglish() []string {
 		words := exp.FindAll([]byte(scanner.Text()), -1)
 		for _, word := range words {
 			if len(word) > 1 {
-				out = append(out, strings.ToLower(string(word)))
+				testwords = append(testwords, strings.ToLower(string(word)))
 				count++
 			}
 		}
@@ -149,8 +152,8 @@ func SampleEnglish() []string {
 	if err := scanner.Err(); err != nil {
 		fmt.Fprintln(os.Stderr, "reading input:", err)
 	}
-	fmt.Println("Read", len(out), "words")
-	return out
+	fmt.Println("Read", len(testwords), "words")
+	return testwords
 }
 
 func ExampleTrie() {

--- a/mintree.go
+++ b/mintree.go
@@ -1,0 +1,71 @@
+package levenshtein
+
+import (
+	"github.com/smartystreets/mafsa"
+)
+
+type MinTree struct {
+	Root MinTreeNode
+}
+
+type MinTreeNode struct {
+	mafsa.MinTreeNode
+	r rune
+}
+
+type mtstackNode struct {
+	vec  sparseVector
+	str  string
+	node *MinTreeNode
+}
+
+func (n *MinTreeNode) traverse(a *SparseAutomaton, vec sparseVector) []string {
+	ret := []string{}
+
+	stack := make([]*mtstackNode, 0, len(n.Edges))
+	var i int
+
+	for r, mt := range n.Edges {
+		nmt := MinTreeNode{*mt, r}
+		stack[i] = &mtstackNode{vec, "", &nmt}
+		i++
+	}
+
+	var top *mtstackNode
+	newVec := vec
+
+	for len(stack) > 0 {
+		top, stack = stack[len(stack)-1], stack[:len(stack)-1]
+		n = top.node
+		if n.r != 0 {
+			newVec = a.Step(top.vec, n.r)
+		}
+
+		// if this is a terminal node - just check if we have
+		// a match and add it to the results
+		if n.Final && len(newVec) > 0 && a.IsMatch(newVec) {
+			ret = append(ret, top.str+string(n.r))
+		}
+
+		if n.Edges != nil && a.CanMatch(newVec) {
+			if n.r != 0 {
+				top.str += string(n.r)
+			}
+
+			for r, child := range n.Edges {
+				stack = append(stack, &mtstackNode{newVec, top.str, &MinTreeNode{*child, r}})
+			}
+		}
+	}
+
+	return ret
+}
+
+// FuzzyMatches returns all the words in the MT that are with maxDist
+// edit distance from s
+func (mt *MinTree) FuzzyMatches(s string, maxDist int) []string {
+	a := NewSparseAutomaton(s, maxDist)
+
+	state := a.Start()
+	return mt.Root.traverse(a, state)
+}

--- a/mintree_test.go
+++ b/mintree_test.go
@@ -9,9 +9,8 @@ import (
 func TestMinTreeFuzzySearch(t *testing.T) {
 	var err error
 
-	words := SampleEnglish()
-	sort.Strings(words)
-	mt, err = NewMinTree(words)
+	sort.Strings(testwords)
+	mt, err = NewMinTree(testwords)
 	if err != nil {
 		t.Fatalf("Could not create MinTree: %q. Exiting.", err)
 	}

--- a/mintree_test.go
+++ b/mintree_test.go
@@ -1,0 +1,35 @@
+package levenshtein
+
+import (
+	"fmt"
+	"sort"
+	"testing"
+)
+
+func TestMinTreeFuzzySearch(t *testing.T) {
+	var err error
+
+	words := SampleEnglish()
+	sort.Strings(words)
+	mt, err = NewMinTree(words)
+	if err != nil {
+		t.Fatalf("Could not create MinTree: %q. Exiting.", err)
+	}
+
+	matches := mt.FuzzyMatches("danger", 2)
+	fmt.Printf("Fuzzymatch count: %d.\n", len(matches))
+	for _, match := range matches {
+		fmt.Println(match)
+	}
+}
+
+var mt *MinTree
+
+func BenchmarkMinTree(b *testing.B) {
+	if mt == nil {
+		return
+	}
+	for i := 0; i < b.N; i++ {
+		mt.FuzzyMatches("holocaust", 2)
+	}
+}


### PR DESCRIPTION
The first commit is just a clean up.

The rest of the commits adapt the SparseAutomaton to work with the rune type since that is what the mafsa package works with internally and add the MinTree-based implementation of the levenshtein automaton. The goal of using the mafsa package is to save memory by using the FSA it implements instead of a Trie. mafsa also implements a binary representation of the FSA allowing for it to be written to disk in an efficient way which is a desirable property.

The (micro) benchmark added shows that the MinTree version is about 34% slower which is not really unexpected considering that it operates on decoded runes. Both should be fast enough for most use cases though. On my i7 the Trie version takes about 2.5 milliseconds to generate fuzzy matches for a term while the mafsa version takes about 3.3 milliseconds.

The next thing to do is to think about how to best make use of these automata in the bleve text indexing library...
