### PR TITLE
Use a non-archived mafsa fork

### DIFF
--- a/levenshtein_test.go
+++ b/levenshtein_test.go
@@ -39,7 +39,8 @@ func TestSparseAutomaton(t *testing.T) {
 					}
 
 				}
-				fmt.Println("----\n")
+				fmt.Println("----")
+				fmt.Println()
 			}
 		}
 	}

--- a/mintree.go
+++ b/mintree.go
@@ -6,7 +6,7 @@ import (
 	"io"
 	"io/ioutil"
 
-	"github.com/smartystreets/mafsa"
+	"github.com/rubenv/mafsa"
 )
 
 type MinTree struct {

--- a/mintree.go
+++ b/mintree.go
@@ -6,7 +6,7 @@ import (
 	"io"
 	"io/ioutil"
 
-	"github.com/rubenv/mafsa"
+	"github.com/Shugyousha/mafsa"
 )
 
 type MinTree struct {


### PR DESCRIPTION
We've found crashes that @Shugyousha's [unmerged work](https://github.com/smartystreets-archives/mafsa/pull/8) fixes.

The original mafsa repo is now archived and doesn't seem ready to accept PRs anymore. I just picked a fork that had the changes I need on master.
Maybe @Shugyousha would prefer to merge their branch on their own mafsa repo so it is their repo that is depended on?
